### PR TITLE
Added min/max filters for date/price on Housing and Ad models

### DIFF
--- a/api/src/ads/api_views.py
+++ b/api/src/ads/api_views.py
@@ -10,6 +10,7 @@ from ads.filters import AdFilter
 class AdListCreate(GenericPostListCreate):
     queryset = Ad.objects.all()
     serializer_class = AdSerializer
+    search_fields = ['title', 'features']
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = AdFilter
 

--- a/api/src/ads/api_views.py
+++ b/api/src/ads/api_views.py
@@ -2,15 +2,16 @@ from common.generics.generic_post_api_views import GenericPostListCreate, Generi
     GenericCommentListCreate, GenericCommentRetrieveUpdateDestroy, GenericUserExtension
 from .models import Ad, AdComment
 from .serializers import AdSerializer, AdCommentSerializer
-
+from django_filters import rest_framework as filters
+from ads.filters import AdFilter
 
 # HTTP GET: Returns a list of ads
 # HTTP POST: Creates an ad
 class AdListCreate(GenericPostListCreate):
     queryset = Ad.objects.all()
     serializer_class = AdSerializer
-    filter_fields = ['region', 'datetime_created', 'creator', 'category', 'price', ]
-    search_fields = ['title', 'features', ]
+    filter_backends = (filters.DjangoFilterBackend,)
+    filterset_class = AdFilter
 
 
 # HTTP GET: Returns an ad

--- a/api/src/ads/filters.py
+++ b/api/src/ads/filters.py
@@ -1,0 +1,20 @@
+
+from django_filters import rest_framework as filters
+from .models import Ad
+
+class AdFilter(filters.FilterSet):
+    # More on lookup_expr syntax: https://django-filter.readthedocs.io/en/latest/ref/filters.html
+    # https://docs.djangoproject.com/en/3.0/ref/models/querysets/#field-lookups
+    # gte = greater than or equal to
+    # lte = less than or equal to
+
+    min_price = filters.NumberFilter(field_name='price', lookup_expr='gte')
+    max_price = filters.NumberFilter(field_name='price', lookup_expr='lte')
+    min_date = filters.DateTimeFilter(field_name='datetime_created', lookup_expr='gte')
+    max_date = filters.DateTimeFilter(field_name='datetime_created', lookup_expr='lte')
+
+    class Meta: 
+        model = Ad
+        fields = ['min_price', 'max_price', 'min_date', 'max_date', 
+                'region', 'datetime_created', 'creator', 'category', 
+                'price', 'title', 'features']

--- a/api/src/housing/api_views.py
+++ b/api/src/housing/api_views.py
@@ -2,6 +2,8 @@ from common.generics.generic_post_api_views import GenericPostListCreate, Generi
     GenericCommentListCreate, GenericCommentRetrieveUpdateDestroy, GenericUserExtension
 from .models import Housing, HousingComment
 from .serializers import HousingSerializer, HousingCommentSerializer
+from django_filters import rest_framework as filters
+from housing.filters import HousingFilter
 
 
 # HTTP GET: Returns a list of housing posts
@@ -9,9 +11,8 @@ from .serializers import HousingSerializer, HousingCommentSerializer
 class HousingListCreate(GenericPostListCreate):
     queryset = Housing.objects.all()
     serializer_class = HousingSerializer
-    filter_fields = ['region', 'datetime_created', 'creator', 'category', 'price', 'term',
-                     'street_address', 'city', 'division', 'country', ]
-    search_fields = ['title', 'features', 'city', 'division', 'country', ]
+    filter_backends = (filters.DjangoFilterBackend,)
+    filterset_class = HousingFilter
 
 
 # HTTP GET: Returns a housing post

--- a/api/src/housing/api_views.py
+++ b/api/src/housing/api_views.py
@@ -11,6 +11,7 @@ from housing.filters import HousingFilter
 class HousingListCreate(GenericPostListCreate):
     queryset = Housing.objects.all()
     serializer_class = HousingSerializer
+    search_fields = ['title', 'features']
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = HousingFilter
 

--- a/api/src/housing/filters.py
+++ b/api/src/housing/filters.py
@@ -1,0 +1,21 @@
+
+from django_filters import rest_framework as filters
+from .models import Housing
+
+class HousingFilter(filters.FilterSet):
+    # More on lookup_expr syntax: https://django-filter.readthedocs.io/en/latest/ref/filters.html
+    # https://docs.djangoproject.com/en/3.0/ref/models/querysets/#field-lookups
+    # gte = greater than or equal to
+    # lte = less than or equal to
+
+    min_price = filters.NumberFilter(field_name='price', lookup_expr='gte')
+    max_price = filters.NumberFilter(field_name='price', lookup_expr='lte')
+    min_date = filters.DateTimeFilter(field_name='datetime_created', lookup_expr='gte')
+    max_date = filters.DateTimeFilter(field_name='datetime_created', lookup_expr='lte')
+
+    class Meta: 
+        model = Housing
+        fields = ['min_price', 'max_price', 'min_date', 'max_date', 
+                'region', 'datetime_created', 'creator', 'category', 
+                'price', 'term', 'street_address', 'city', 
+                'division', 'country', 'title', 'features']


### PR DESCRIPTION
I wrote separate classes extending django_filters.rest_framework.FilterSet for the filters for Ad and Housing. I'm pretty sure the FilterSet autoinfers the type of filter, and we don't need to explicitly state which filters are searchable anymore. All the filters seem to be working on my end but hopefully someone else can verify before I merge this pr