### PR TITLE
feature/PullToRefresh

### DIFF
--- a/mobile/src/src/components/Community/Feed/FeedContainer.jsx
+++ b/mobile/src/src/components/Community/Feed/FeedContainer.jsx
@@ -1,8 +1,9 @@
-import React, { Component } from 'react';
-import { StyleSheet, View, FlatList } from 'react-native';
+import React, { Component, useState } from 'react';
+import { StyleSheet, View, FlatList, RefreshControl } from 'react-native';
 import EventView from './EventView';
 import PostView from './PostView';
 import { EventsEndpoint, PostsEndpoint } from '../../../utils/endpoints';
+import { ThemeProvider } from '@react-navigation/native';
 
 class FeedContainer extends Component {
   state = {
@@ -17,6 +18,7 @@ class FeedContainer extends Component {
     nextPageExistsP: true,
     nextPageExistsE: true,
     lastListDate: null,
+    refreshing: false,
   };
 
   componentDidMount = () => {
@@ -30,15 +32,57 @@ class FeedContainer extends Component {
     }
   };
 
-  // posts
+  wait = (timeout) => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, timeout);
+    });
+  };
 
+  onRefresh = () => {
+    this.setState({
+      refreshing: true,
+      nextPageP: 1,
+      nextPageE: 1,
+    });
+
+    this.refreshPosts();
+    this.refreshEvents();
+
+    this.wait(1000).then(() => {
+      this.setState({ refreshing: false });
+    });
+  };
+
+  // getting of posts when refreshing
+  // (resets post list to most recent ones)
+
+  refreshPosts = () => {
+    PostsEndpoint.list(
+      1,
+      this.state.filtersP,
+      (response) => {
+        this.setState({
+          posts: [],
+        });
+        this.setState({
+          posts: response.data.results,
+          hasNewPosts: true,
+          nextPageExistsP: response.data.next !== null,
+        });
+      },
+      (error) => {
+        console.log('error: ', error);
+      }
+    );
+  };
+
+  // getting of posts when paginating
   getPosts = () => {
     PostsEndpoint.list(
       this.state.nextPageP,
       this.state.filtersP,
       (response) => {
         let seen = {};
-
         this.setState({
           posts: this.state.posts
             .concat(response.data.results)
@@ -55,8 +99,24 @@ class FeedContainer extends Component {
     );
   };
 
-  // events
+  refreshEvents = () => {
+    EventsEndpoint.list(
+      this.state.nextPageE,
+      this.state.filtersE,
+      (response) => {
+        this.setState({
+          events: response.data.results,
+          hasNewEvents: true,
+          nextPageExistsE: response.data.next !== null,
+        });
+      },
+      (error) => {
+        console.log('error: ', error);
+      }
+    );
+  };
 
+  // getting of events when paginating
   getEvents = () => {
     EventsEndpoint.list(
       this.state.nextPageE,
@@ -177,9 +237,16 @@ class FeedContainer extends Component {
     return (
       <View style={styles.feedContainer}>
         <FlatList
+          refreshControl={
+            <RefreshControl
+              refreshing={this.state.refreshing}
+              onRefresh={this.onRefresh}
+            />
+          }
           data={this.getList()}
           keyExtractor={(item, i) => i.toString()}
           renderItem={this.renderItem}
+          onEndReachedThreshold={0.5}
           onEndReached={() => {
             if (this.state.nextPageExistsP) {
               this.getPosts();
@@ -188,6 +255,7 @@ class FeedContainer extends Component {
               this.getEvents();
             }
           }}
+          showsVerticalScrollIndicator={false}
         />
       </View>
     );

--- a/mobile/src/src/components/Community/Feed/FeedContainer.jsx
+++ b/mobile/src/src/components/Community/Feed/FeedContainer.jsx
@@ -1,9 +1,8 @@
-import React, { Component, useState } from 'react';
+import React, { Component } from 'react';
 import { StyleSheet, View, FlatList, RefreshControl } from 'react-native';
 import EventView from './EventView';
 import PostView from './PostView';
 import { EventsEndpoint, PostsEndpoint } from '../../../utils/endpoints';
-import { ThemeProvider } from '@react-navigation/native';
 
 class FeedContainer extends Component {
   state = {
@@ -32,12 +31,7 @@ class FeedContainer extends Component {
     }
   };
 
-  wait = (timeout) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, timeout);
-    });
-  };
-
+  // pull to refresh
   onRefresh = () => {
     this.setState({
       refreshing: true,
@@ -45,25 +39,10 @@ class FeedContainer extends Component {
       nextPageE: 1,
     });
 
-    this.refreshPosts();
-    this.refreshEvents();
-
-    this.wait(1200).then(() => {
-      this.setState({ refreshing: false });
-    });
-  };
-
-  // getting of posts when refreshing
-  // (resets post list to most recent ones)
-
-  refreshPosts = () => {
     PostsEndpoint.list(
       1,
       this.state.filtersP,
       (response) => {
-        this.setState({
-          posts: [],
-        });
         this.setState({
           posts: response.data.results,
           hasNewPosts: true,
@@ -72,6 +51,23 @@ class FeedContainer extends Component {
       },
       (error) => {
         console.log('error: ', error);
+      }
+    );
+
+    EventsEndpoint.list(
+      1,
+      this.state.filtersE,
+      (response) => {
+        this.setState({
+          events: response.data.results,
+          hasNewEvents: true,
+          nextPageExistsE: response.data.next !== null,
+          refreshing: false,
+        });
+      },
+      (error) => {
+        console.log('error: ', error);
+        this.setState({ refreshing: false });
       }
     );
   };
@@ -91,23 +87,6 @@ class FeedContainer extends Component {
             ),
           hasNewPosts: true,
           nextPageExistsP: response.data.next !== null,
-        });
-      },
-      (error) => {
-        console.log('error: ', error);
-      }
-    );
-  };
-
-  refreshEvents = () => {
-    EventsEndpoint.list(
-      this.state.nextPageE,
-      this.state.filtersE,
-      (response) => {
-        this.setState({
-          events: response.data.results,
-          hasNewEvents: true,
-          nextPageExistsE: response.data.next !== null,
         });
       },
       (error) => {

--- a/mobile/src/src/components/Community/Feed/FeedContainer.jsx
+++ b/mobile/src/src/components/Community/Feed/FeedContainer.jsx
@@ -48,7 +48,7 @@ class FeedContainer extends Component {
     this.refreshPosts();
     this.refreshEvents();
 
-    this.wait(1000).then(() => {
+    this.wait(1200).then(() => {
       this.setState({ refreshing: false });
     });
   };

--- a/mobile/src/src/components/Housing/Listings/ListingsContainer.jsx
+++ b/mobile/src/src/components/Housing/Listings/ListingsContainer.jsx
@@ -23,23 +23,13 @@ class ListingContainer extends Component {
     });
   };
 
+  // pull to refresh
   onRefresh = () => {
     this.setState({
       refreshing: true,
       nextPage: 1,
     });
 
-    this.refreshListings();
-
-    this.wait(1200).then(() => {
-      this.setState({ refreshing: false });
-    });
-  };
-
-  // getting of posts when refreshing
-  // (resets post list to most recent ones)
-
-  refreshListings = () => {
     ListingsEndpoint.list(
       1,
       this.state.filters,
@@ -48,10 +38,12 @@ class ListingContainer extends Component {
           listings: response.data.results,
           hasNewListings: true,
           nextPageExists: response.data.next !== null,
+          refreshing: false,
         });
       },
       (error) => {
         console.log('error: ', error);
+        this.setState({ refreshing: false });
       }
     );
   };

--- a/mobile/src/src/components/Housing/Listings/ListingsContainer.jsx
+++ b/mobile/src/src/components/Housing/Listings/ListingsContainer.jsx
@@ -1,18 +1,59 @@
-import React, { Component } from "react";
-import { StyleSheet, View, FlatList } from "react-native";
-import ListingView from "./ListingView";
-import { ListingsEndpoint, CommentsEndpoint } from "../../../utils/endpoints";
+import React, { Component } from 'react';
+import { StyleSheet, View, FlatList, RefreshControl } from 'react-native';
+import ListingView from './ListingView';
+import { ListingsEndpoint, CommentsEndpoint } from '../../../utils/endpoints';
 
 class ListingContainer extends Component {
   state = {
     listings: [],
     nextPage: 1,
     filters: {},
+    hasNewListings: false,
     nextPageExists: true,
+    refreshing: false,
   };
 
   componentDidMount = () => {
     this.getListings();
+  };
+
+  wait = (timeout) => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, timeout);
+    });
+  };
+
+  onRefresh = () => {
+    this.setState({
+      refreshing: true,
+      nextPage: 1,
+    });
+
+    this.refreshListings();
+
+    this.wait(1000).then(() => {
+      this.setState({ refreshing: false });
+    });
+  };
+
+  // getting of posts when refreshing
+  // (resets post list to most recent ones)
+
+  refreshListings = () => {
+    ListingsEndpoint.list(
+      1,
+      this.state.filters,
+      (response) => {
+        this.setState({
+          listings: response.data.results,
+          hasNewListings: true,
+          nextPageExists: response.data.next !== null,
+        });
+      },
+      (error) => {
+        console.log('error: ', error);
+      }
+    );
   };
 
   getListings = () => {
@@ -96,6 +137,12 @@ class ListingContainer extends Component {
     return (
       <View style={styles.listingContainer}>
         <FlatList
+          refreshControl={
+            <RefreshControl
+              refreshing={this.state.refreshing}
+              onRefresh={this.onRefresh}
+            />
+          }
           data={this.state.listings}
           keyExtractor={(item, i) => i.toString()}
           renderItem={this.renderItem}
@@ -104,6 +151,7 @@ class ListingContainer extends Component {
               this.getListings();
             }
           }}
+          showsVerticalScrollIndicator={false}
         />
       </View>
     );

--- a/mobile/src/src/components/Housing/Listings/ListingsContainer.jsx
+++ b/mobile/src/src/components/Housing/Listings/ListingsContainer.jsx
@@ -31,7 +31,7 @@ class ListingContainer extends Component {
 
     this.refreshListings();
 
-    this.wait(1000).then(() => {
+    this.wait(1200).then(() => {
       this.setState({ refreshing: false });
     });
   };

--- a/mobile/src/src/components/Market/Ads/AdsContainer.jsx
+++ b/mobile/src/src/components/Market/Ads/AdsContainer.jsx
@@ -17,29 +17,13 @@ class AdsContainer extends Component {
     this.getAds();
   };
 
-  wait = (timeout) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, timeout);
-    });
-  };
-
+  // pull to refresh
   onRefresh = () => {
     this.setState({
       refreshing: true,
       nextPage: 1,
     });
 
-    this.refreshAds();
-
-    this.wait(1200).then(() => {
-      this.setState({ refreshing: false });
-    });
-  };
-
-  // getting of posts when refreshing
-  // (resets post list to most recent ones)
-
-  refreshAds = () => {
     AdsEndpoint.list(
       1,
       this.state.filters,
@@ -51,10 +35,12 @@ class AdsContainer extends Component {
           ads: response.data.results,
           hasNewAds: true,
           nextPageExists: response.data.next !== null,
+          refreshing: false,
         });
       },
       (error) => {
         console.log('error: ', error);
+        this.setState({ refreshing: false });
       }
     );
   };

--- a/mobile/src/src/components/Market/Ads/AdsContainer.jsx
+++ b/mobile/src/src/components/Market/Ads/AdsContainer.jsx
@@ -31,7 +31,7 @@ class AdsContainer extends Component {
 
     this.refreshAds();
 
-    this.wait(1000).then(() => {
+    this.wait(1200).then(() => {
       this.setState({ refreshing: false });
     });
   };


### PR DESCRIPTION
This ticket implements a pull to refresh feature on each page that
has postings. If a new post is created while the user has loaded the
page, they can pull down at the top to call the new posts.

Expo Project to Test Code: https://expo.io/@trentstauffuw/umigrate

**(TIP: you can test the code on desktop by pressing the "open project in the browser" and then "open project" and then "open project in expo". As you can see, this means that since I am on an iPhone, I can test my code on android. But, for you android users you'll need to share the project link so I can run it locally on my iPhone.)** 

(No tests as this is not a component, RefreshControl is a property of FlatList)

Closes #315 

(GIF not to speed obviously, and the amount of time the pull stays active can be changed. Let me know what you think, try it local with the Expo Project link and see)
![video0](https://user-images.githubusercontent.com/53923200/99621899-0277d200-29f7-11eb-86a0-a4d279f6b14b.gif)

