### PR TITLE
Bug fix: Fix CommentsScreen error

### DIFF
--- a/app/src/src/screens/comments/CommentsScreen.jsx
+++ b/app/src/src/screens/comments/CommentsScreen.jsx
@@ -25,6 +25,7 @@ const CommentsScreen = ({ navigation, route }) => {
         itemViews={itemViews}
         filtersList={[commentsFilters]}
         scrollRef={ref}
+        route={route}
       />
       <CreateItemModal navigation={navigation} />
     </View>


### PR DESCRIPTION
We forgot to pass `route` as a prop to the `FeedContainer` in the `CommentsScreen` before, so an error came up when we tried to access `route.params`.